### PR TITLE
Add support for the pdnsd format

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This blocklist is left in the [public domain (Do What The Fuck You Want To Publi
 
 ### pdnsd format
 
-[Blocklist in pdnsd format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/pdnsd.txt) to use with the [pdnsd](https://web.archive.org/web/20201203080556/http://members.home.nl/p.a.rombouts/pdnsd/) caching DNS proxy server software.
+[Blocklist in pdnsd format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/pdnsd.txt) to use with the [pdnsd](https://wiki.archlinux.org/title/Pdnsd) caching DNS proxy server software.
 
 ## Fediverse formats
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This blocklist is left in the [public domain (Do What The Fuck You Want To Publi
 
 [Blocklist in Dnsmasq format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/dnsmasq.txt) to use with the [Dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) DNS server software.
 
+### pdnsd format
+
+[Blocklist in pdnsd format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/pdnsd.txt) to use with the [pdnsd](https://web.archive.org/web/20201203080556/http://members.home.nl/p.a.rombouts/pdnsd/) caching DNS proxy server software.
+
 ## Fediverse formats
 
 ### Mastodon

--- a/scripts/pdnsd.py
+++ b/scripts/pdnsd.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Generate a pdnsd compatible configuration file of domains to negate from the content of the `sources` folder.
+
+Usage:
+  python pdsnd.py > pdnsd.txt
+"""
+
+
+def get_header() -> str:
+    """Return header for pdnsd config file"""
+    with open("sources/headers/default.txt", "r") as header:
+        return header.read()
+
+
+def get_domains() -> set:
+    """Return set of domains to block"""
+    domains = set()  # Using set to eliminate potential duplicates
+    with open("sources/tlds.txt", "r") as tld_list:
+        for d in tld_list.readlines():
+            domains.add(d.strip())
+    with open("sources/domains.txt", "r") as domain_list:
+        for d in domain_list.readlines():
+            domains.add(d.strip())
+    return domains
+
+
+def format_pdnsd(domain: str) -> str:
+    """Return entry formatted for pdnsd"""
+    return "neg {{name={}; types=domain;}}".format(domain.strip())
+
+
+def main() -> None:
+    """Print out a full pdnsd config file ready to include"""
+    print(get_header())
+    for domain in sorted(get_domains()):
+        print(format_pdnsd(domain))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -52,6 +52,8 @@ python scripts/hosts.py > hosts.txt
 python scripts/hosts_ipv6.py > hosts_ipv6.txt
 ### DNSmasq
 python scripts/dnsmasq.py > dnsmasq.txt
+### pdnsd
+python scripts/pdnsd.py > pdnsd.txt
 
 ## For browser extensions
 ### Adblock


### PR DESCRIPTION
This adds a new script, `pdnsd.py`, used to generate a new output file, `pdnsd.txt`, which downstream users can consume into their pdnsd configurations to negate DNS lookups of the included domain; see https://wiki.archlinux.org/title/Pdnsd#Name_blocking for details.

pdnsd’s development seems to sadly have halted, but it is still included with many Linux distributions, still works perfectly acceptably, and still seems to be only piece of software doing just what it does.

The ArchWiki’s entry on it is probably the best current source on it: https://wiki.archlinux.org/title/Pdnsd