### PR TITLE
Added sites to Plagiarism.txt

### DIFF
--- a/sources/domains/Copycats/Plagiarism.txt
+++ b/sources/domains/Copycats/Plagiarism.txt
@@ -5,3 +5,4 @@ lqymcgn.com
 fatiharkan.com
 truecannanc.com
 routepacket.com
+adgxnaqn.com

--- a/sources/domains/Copycats/Plagiarism.txt
+++ b/sources/domains/Copycats/Plagiarism.txt
@@ -1,2 +1,7 @@
 # https://twitter.com/gamingonlinux/status/1752294833983520771
 chichester.news
+talumeetings.com
+lqymcgn.com
+fatiharkan.com
+truecannanc.com
+routepacket.com

--- a/sources/domains/Copycats/Plagiarism.txt
+++ b/sources/domains/Copycats/Plagiarism.txt
@@ -1,8 +1,2 @@
 # https://twitter.com/gamingonlinux/status/1752294833983520771
 chichester.news
-talumeetings.com
-lqymcgn.com
-fatiharkan.com
-truecannanc.com
-routepacket.com
-adgxnaqn.com

--- a/sources/domains/Malware/Malvertisement redirection.txt
+++ b/sources/domains/Malware/Malvertisement redirection.txt
@@ -155,3 +155,9 @@ naruckn.sk
 instalater-zilina.sk
 eloi-berlinger.fr
 milisium.fr
+talumeetings.com
+lqymcgn.com
+fatiharkan.com
+truecannanc.com
+routepacket.com
+adgxnaqn.com


### PR DESCRIPTION
Added several sites to Plagiarism.txt that have content copied from another website (lqymcgn.com redirects to adgxnaqn.com):

Originals:
https://www.newhaven.edu/news/blog/2021/cores.php
https://www.newhaven.edu/news/blog/2021/students-present-cybersecurity-research.php
https://www.newhaven.edu/news/blog/2022/cptc-finals.php

Plaigarism:
https://www.talumeetings.com/news/blog/2021/cores.php
http://www.fatiharkan.com/news/blog/2021/cores.php
https://www.truecannanc.com/news/blog/2021/cores.php
https://www.talumeetings.com/news/blog/2021/students-present-cybersecurity-research.php
http://www.fatiharkan.com/news/blog/2021/students-present-cybersecurity-research.php
https://www.truecannanc.com/news/blog/2021/students-present-cybersecurity-research.php
https://www.talumeetings.com/news/blog/2022/cptc-finals.php
http://www.fatiharkan.com/news/blog/2022/cptc-finals.php
https://www.truecannanc.com/news/blog/2022/cptc-finals.php
https://www.routepacket.com/news/blog/2022/cptc-finals.php
https://adgxnaqn.com/news/blog/2022/cptc-finals.php