### PR TITLE
Add support for Unbound’s configuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ This blocklist is left in the [public domain (Do What The Fuck You Want To Publi
 
 [Blocklist in pdnsd format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/pdnsd.txt) to use with the [pdnsd](https://wiki.archlinux.org/title/Pdnsd) caching DNS proxy server software.
 
+### Unbound format
+
+[Blocklist in Unbound configuration format](https://raw.githubusercontent.com/NotaInutilis/Super-SEO-Spam-Suppressor/main/unbound.txt) to use with the [Unbound](https://nlnetlabs.nl/projects/unbound/) validating, recursive, caching DNS resolver.
+
 ## Fediverse formats
 
 ### Mastodon

--- a/scripts/unbound.py
+++ b/scripts/unbound.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Generate an Unbound compatible configuration file of domains to refuse from the content of the `sources` folder.
+
+Usage:
+  python unbound.py > unbound.txt
+"""
+
+
+def get_header() -> str:
+    """Return header for Unbound config file"""
+    with open("sources/headers/default.txt", "r") as header:
+        return header.read()
+
+
+def get_domains() -> set:
+    """Return set of domains to block"""
+    domains = set()  # Using set to eliminate potential duplicates
+    with open("sources/tlds.txt", "r") as tld_list:
+        for d in tld_list.readlines():
+            domains.add(d.strip())
+    with open("sources/domains.txt", "r") as domain_list:
+        for d in domain_list.readlines():
+            domains.add(d.strip())
+    return domains
+
+
+def format_unbound(domain: str) -> str:
+    """Return entry formatted for Unbound"""
+    return f"local-zone: \"{domain.strip()}\" always_refuse"
+
+
+def main() -> None:
+    """Print out an Unbound config file ready to include"""
+    print(get_header())
+    for domain in sorted(get_domains()):
+        print(format_unbound(domain))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -60,6 +60,8 @@ python scripts/hosts_ipv6.py > hosts_ipv6.txt
 python scripts/dnsmasq.py > dnsmasq.txt
 ### pdnsd
 python scripts/pdnsd.py > pdnsd.txt
+### Unbound
+python scripts/unbound.py > unbound.txt
 
 ## For browser extensions
 ### Adblock


### PR DESCRIPTION
This adds a new script, `unbound.py`, used to generate a new output file, `unbound.txt`, which downstream users can consume into their Unbound configurations to refuse DNS lookups of the included domains; see https://wiki.archlinux.org/title/Unbound#Domain_blacklisting for an example.

From https://nlnetlabs.nl/projects/unbound/about/ :

> Unbound is a validating, recursive, caching DNS resolver. It is
> designed to be fast and lean and incorporates modern features
> based on open standards.
>
> […]
>
> Unbound runs on all Linux and BSD distributions, as well as macOS,
> with packages available for most platforms. It is included in the
> base-system of all major BSD operating systems and in the standard
> repositories of most Linux distributions. […]

This is pretty much copy/pasted and slightly modified from my pDNSd commit from ~1½ year back:
https://github.com/NotaInutilis/Super-SEO-Spam-Suppressor/pull/5 :)