### PR TITLE
Add Peter Lowe’s list to imported lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This blocklist borrows from the following projects:
 - the [fake (wildcard domains) blocklist](https://github.com/hagezi/dns-blocklists/blob/main/wildcard/fake-onlydomains.txt) from hagezi's [DNS Blocklists](https://github.com/hagezi/dns-blocklists) ([GNU General Public License v3.0](https://github.com/hagezi/dns-blocklists/blob/main/LICENSE))
 - the [Anti-Malware Domains blocklist](https://github.com/DandelionSprout/adfilt/blob/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt) from DandelionSprout's [adfilt](https://github.com/DandelionSprout/adfilt) ([Dandelicence](https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md)).
 - the [full plus domains blocklist](https://github.com/fmhy/FMHYFilterlist/blob/main/filterlist-domains.txt) from fmhy's FMHY [Filterlist](https://github.com/fmhy/FMHYFilterlist) ([GNU General Public License v3.0](https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE))
+- the [ad and tracking server blocklist](https://pgl.yoyo.org/as/serverlist.php?hostformat=plain) maintained by [Peter Lowe](https://pgl.yoyo.org/adservers/) ([McRae General Public License](https://pgl.yoyo.org/license/))
 
 ## Fandom (formerly known as Wikia)
 

--- a/sources/imports/importlist.txt
+++ b/sources/imports/importlist.txt
@@ -20,3 +20,4 @@ Huge AI Blocklist hosts.txt|https://raw.githubusercontent.com/laylavish/uBlockOr
 Fake.txt|https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/fake-onlydomains.txt
 Anti Malware Domains.txt|https://raw.githubusercontent.com/DandelionSprout/adfilt/refs/heads/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareDomains.txt
 FMHY domains plus.txt|https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlist-domains.txt
+Peter Lowe ad and tracking server blocklist.txt|https://pgl.yoyo.org/adservers/serverlist.php?hostformat=plain&showintro=0&mimetype=plaintext


### PR DESCRIPTION
The list at https://pgl.yoyo.org/adservers/ maintained by Peter Lowe has been around for years and seems to be well maintained and respected. The author also explicitly says to “Feel free to combine this list with yours or lists from other sites and put it up on the web, though!” which, well, is exactly what we’re doing here. :)

I don’t know if this is out scope for this list though, since these domains will rarely (if ever) show up in search results directly. If so, feel free to close without merging!