### PR TITLE
Add some valid domain names in the RU. zone to the allowlist

### DIFF
--- a/sources/imports/allowlist.txt
+++ b/sources/imports/allowlist.txt
@@ -7,3 +7,6 @@ blake-taylor.com
 bonprix.fr
 medium.com
 waw.pl
+spb.ru
+avtotent-spb.ru
+pes-spb.ru


### PR DESCRIPTION
Add spb.ru, avtotent-spb.ru and pes-spb.ru to the allowlist.

This PR should fix the https://github.com/NotaInutilis/Super-SEO-Spam-Suppressor/issues/45 issue