### PR TITLE
add the wikipedia blocklist from https://meta.wikimedia.org/wiki/Spam_blacklist

### DIFF
--- a/sources/domains/Wikipedia abuse lists/README.md
+++ b/sources/domains/Wikipedia abuse lists/README.md
@@ -1,0 +1,1 @@
+`sed` for the [Spam blacklist](https://meta.wikimedia.org/wiki/Spam_blacklist): `sed  "s|\\\[^.]||g;s|\\\||g;s|.*(.*||g;s|.*\[.*||g;s|^\\.||g;s|\s#.*||g;s|.*/.*||g;s|.*{.*||g;s|#.*||g;s|.*\*.*||g;s|.*+.*||g;s|.*?.*||g;s|.*\\^.*||g;"'/.\+\..\+/!d'`

--- a/sources/domains/Wikipedia abuse lists/Spam blacklist.txt
+++ b/sources/domains/Wikipedia abuse lists/Spam blacklist.txt
@@ -1,3 +1,6 @@
+# https://meta.wikimedia.org/wiki/Spam_blacklist
+# Retrieved on 2025/11/09
+
 tvsou.com
 eaeaq.info
 98.to


### PR DESCRIPTION
i think that this should be added because the wikimedia spam blocklist only exists to remove spammy references from their projects amongst other things.
i manually checked something like 5000 lines of it, and i can say that it's pretty good and shouldn't cause problems

i also used `sed  "s|\\\[^.]||g;s|\\\||g;s|.*(.*||g;s|.*\[.*||g;s|^\\.||g;s|\s#.*||g;s|.*/.*||g;s|.*{.*||g;s|#.*||g;s|.*\*.*||g;s|.*+.*||g;s|.*?.*||g;s|.*\\^.*||g;"'/.\+\..\+/!d'` to remove wikipedia's regex from the domains

note: i didn't CI it so you might want to do that after merging my commit