### PR TITLE
Daily spam haul

### DIFF
--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,3 +1,4 @@
+ostechnix.com
 thelinuxvault.net
 hightechmind.io
 euphyra.fr

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,3 +1,4 @@
+www.l-expert-comptable.com/a/*
 ostechnix.com
 thelinuxvault.net
 hightechmind.io

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -54,40 +54,6 @@ mycleverai.com
 docai.net
 aiforswes.com
 
-# By Duduledaron™
-ad-immo.fr
-alize-deco.fr
-auto-max.fr
-bricoworld.it
-ccl-avocat.fr
-chevalier-immo.fr
-classique-auto.fr
-electricien-38.fr
-eloasweetashoney.com
-fashion-guide.fr
-gennevilliers-tourisme.fr
-gite-lenichoir.fr
-healthyweight4children.org.uk
-hotel-arpege.fr
-immo-queven.fr
-juegatelamesa.com
-laurore-immo.fr
-na-web.fr
-parking-alizes.fr
-percy-auto.fr
-portes-store.fr
-rairies-facade.fr
-relojea.es
-sis-fashion.at
-synergie-web.fr
-veterinairebeaublanc.fr
-visa-chinois.fr
-votre-banque.fr
-web-city.fr
-web-sio.fr
-r-14d3dfb6b4.pages.dev
-r-ce76877dc1.pages.dev
-
 # Datadog
 datadoghq.com
 christophetd.fr

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,5 +1,3 @@
-hiway.fr/blog/*
-www.l-expert-comptable.com/a/*
 ostechnix.com
 thelinuxvault.net
 hightechmind.io

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -56,6 +56,40 @@ mycleverai.com
 docai.net
 aiforswes.com
 
+# By Duduledaron™
+ad-immo.fr
+alize-deco.fr
+auto-max.fr
+bricoworld.it
+ccl-avocat.fr
+chevalier-immo.fr
+classique-auto.fr
+electricien-38.fr
+eloasweetashoney.com
+fashion-guide.fr
+gennevilliers-tourisme.fr
+gite-lenichoir.fr
+healthyweight4children-org.uk
+hotel-arpege.fr
+immo-queven.fr
+juegatelamesa.com
+laurore-immo.fr
+na-web.fr
+parking-alizes.fr
+percy-auto.fr
+portes-store.fr
+rairies-facade.fr
+relojea.es
+sis-fashion.at
+synergie-web.fr
+veterinairebeaublanc.fr
+visa-chinois.fr
+votre-banque.fr
+web-city.fr
+web-sio.fr
+r-14d3dfb6b4.pages.dev
+r-ce76877dc1.pages.dev
+
 # Datadog
 datadoghq.com
 christophetd.fr

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,5 +1,3 @@
-ostechnix.com
-thelinuxvault.net
 hightechmind.io
 euphyra.fr
 shipwithai.xyz

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -69,7 +69,7 @@ eloasweetashoney.com
 fashion-guide.fr
 gennevilliers-tourisme.fr
 gite-lenichoir.fr
-healthyweight4children-org.uk
+healthyweight4children.org.uk
 hotel-arpege.fr
 immo-queven.fr
 juegatelamesa.com

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,3 +1,4 @@
+thelinuxvault.net
 hightechmind.io
 euphyra.fr
 shipwithai.xyz

--- a/sources/domains/Generative AI/AI unsorted.txt
+++ b/sources/domains/Generative AI/AI unsorted.txt
@@ -1,3 +1,4 @@
+hiway.fr/blog/*
 www.l-expert-comptable.com/a/*
 ostechnix.com
 thelinuxvault.net

--- a/sources/domains/Slop/Duduledaron.txt
+++ b/sources/domains/Slop/Duduledaron.txt
@@ -1,0 +1,45 @@
+# Sites made by "Duduledaron" <https://github.com/Duduledaron>
+# 
+# The list was extracted from his public repos via GitHub's API
+# https://api.github.com/users/Duduledaron/repos?per_page=100?page=<1,2,3>
+# Then I filtered out everything that didn't end in "-web.git"
+#
+# 9 of the websites were checked, all of them being content farms.
+# Given that the others all have the same workflow, I believe it's safe to
+# blacklist them all.
+
+ad-immo.fr
+alize-deco.fr
+auto-max.fr
+bricoworld.it
+ccl-avocat.fr
+chevalier-immo.fr
+classique-auto.fr
+electricien-38.fr
+eloasweetashoney.com
+fashion-guide.fr
+gennevilliers-tourisme.fr
+gite-lenichoir.fr
+healthyweight4children.org.uk
+hotel-arpege.fr
+immo-queven.fr
+juegatelamesa.com
+laurore-immo.fr
+na-web.fr
+parking-alizes.fr
+percy-auto.fr
+portes-store.fr
+rairies-facade.fr
+relojea.es
+sis-fashion.at
+synergie-web.fr
+veterinairebeaublanc.fr
+visa-chinois.fr
+votre-banque.fr
+web-city.fr
+web-sio.fr
+
+# Those two domains contain exclusively links to the articles of some of the
+# farms above.
+r-14d3dfb6b4.pages.dev
+r-ce76877dc1.pages.dev

--- a/sources/domains/Slop/Duduledaron.txt
+++ b/sources/domains/Slop/Duduledaron.txt
@@ -1,13 +1,11 @@
-# Sites made by "Duduledaron" <https://github.com/Duduledaron>
-# 
+# Duduledaron
+# https://github.com/Duduledaron
+# Legal notices use the name B. D.
+# SIRET : 94260527000027
+
 # The list was extracted from his public repos via GitHub's API
 # https://api.github.com/users/Duduledaron/repos?per_page=100?page=<1,2,3>
-# Then I filtered out everything that didn't end in "-web.git"
-#
-# 9 of the websites were checked, all of them being content farms.
-# Given that the others all have the same workflow, I believe it's safe to
-# blacklist them all.
-
+# Then filtering out everything that didn't end in "-web.git"
 ad-immo.fr
 alize-deco.fr
 auto-max.fr
@@ -39,7 +37,9 @@ votre-banque.fr
 web-city.fr
 web-sio.fr
 
-# Those two domains contain exclusively links to the articles of some of the
-# farms above.
+# Those two domains contain exclusively links to the articles of some of the farms above.
 r-14d3dfb6b4.pages.dev
 r-ce76877dc1.pages.dev
+
+# More sites
+https://lumiqare.fr/confidentialite/

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,3 +1,5 @@
+ostechnix.com
+thelinuxvault.net
 devops.dev
 willyschocolateexperience.com # https://www.theguardian.com/uk-news/2024/feb/27/glasgow-willy-wonka-experience-slammed-as-farce-as-tickets-refunded
 amazingalgorithms.com

--- a/sources/urls/Slop/Content marketing/French.txt
+++ b/sources/urls/Slop/Content marketing/French.txt
@@ -1,5 +1,7 @@
 hiway.fr/blog
+https://www.l-expert-comptable.com/blog
 www.l-expert-comptable.com/a
+https://www.l-expert-comptable.com/c
 weroad.fr/blog
 izi-by-edf.fr/blog
 serveur-prive.net/actualites

--- a/sources/urls/Slop/Content marketing/French.txt
+++ b/sources/urls/Slop/Content marketing/French.txt
@@ -1,3 +1,5 @@
+hiway.fr/blog
+www.l-expert-comptable.com/a
 weroad.fr/blog
 izi-by-edf.fr/blog
 serveur-prive.net/actualites


### PR DESCRIPTION
I've put everything in `Generative AI/AI unsorted.txt`. Tell me if you want them classified somewhere else.

See commit comments for the reasoning on the 4 first commits. 

About the second-last commit, introducing :

# [Duduledaron](https://github.com/Duduledaron)™
_Retired spam artist_

Uses GitHub for everything, so I could `curl` a list of all his repos via GitHub's API and helix my way into

<details><summary>this list</summary>
<p>

```
ad-immo.fr
alize-deco.fr
auto-max.fr
bricoworld.it
ccl-avocat.fr
chevalier-immo.fr
classique-auto.fr
electricien-38.fr
eloasweetashoney.com
fashion-guide.fr
gennevilliers-tourisme.fr
gite-lenichoir.fr
healthyweight4children.org.uk
hotel-arpege.fr
immo-queven.fr
juegatelamesa.com
laurore-immo.fr
na-web.fr
parking-alizes.fr
percy-auto.fr
portes-store.fr
rairies-facade.fr
relojea.es
sis-fashion.at
synergie-web.fr
veterinairebeaublanc.fr
visa-chinois.fr
votre-banque.fr
web-city.fr
web-sio.fr
r-14d3dfb6b4.pages.dev
r-ce76877dc1.pages.dev
```

</p>
</details> 

I've kept my notes on the ones I actually checked below.

I believe they set enough precedent to warrant blacklisting everything from this guy, as I did not find any non-ai site with this method.

I did find one handmade site <https://site-daron.vercel.app/> but it did not match the naming convention of the AI-generated ones and got excluded at helix-selection time. 

--- 

ccl-avocat.fr

https://ccl-avocat.fr/blog

https://ccl-avocat.fr/plan-du-site

Steady stream of 2 articles per day, all looking AI-generated.

---

votre-banque.fr

https://votre-banque.fr/plan-du-site

By the same artist as ccl-avocat.fr, with a particular attention to the [contact form](https://votre-banque.fr/contact/)

---

immo-queven.fr

https://immo-queven.fr/plan-du-site

[Still innovating in the contact form milieu](https://immo-queven.fr/devis-travaux/)

---

laurore-immo.fr

https://laurore-immo.fr/plan-du-site

Went out of his way on the CSS there. Kinda cool actually.

---

ad-immo.fr

https://ad-immo.fr/plan-du-site

r-14d3dfb6b4.pages.dev: exclusively contains links to ad-immo.fr

---

classique-auto.fr

https://classique-auto.fr/plan-du-site/

r-ce76877dc1.pages.dev: exclusively contains links to classique-auto.fr

---

alize-deco.fr

[AI generated images](https://alize-deco.fr/audit-energetique-obligatoire-facultatif), and text very likely too

---

auto-max.fr

AI generated fingers, article content likely too

---

bricoworld.it

https://bricoworld.it/mappa-del-sito

This one I can't read, but given the size of the sitemap and precedent, I'll assume it's a form of content farm.

