### PR TITLE
latest spam haul

### DIFF
--- a/sources/Unsorted Gex/Unsorted Gex domains.txt
+++ b/sources/Unsorted Gex/Unsorted Gex domains.txt
@@ -333,7 +333,6 @@ whatismyip.org
 devx.com
 cncrgroup.com
 okta.com
-thisvsthat.io
 airzerosec.com
 1kosmos.com
 hashtagavocats.com

--- a/sources/domains/Ads business/Evolu8.txt
+++ b/sources/domains/Ads business/Evolu8.txt
@@ -1,0 +1,3 @@
+https://evolu8.fr/
+https://inonobu.fr/
+https://facture-electronique-obligatoire.fr/mentions-legales/

--- a/sources/domains/Generative AI/Dev/English.txt
+++ b/sources/domains/Generative AI/Dev/English.txt
@@ -1,1 +1,2 @@
+devsolus.com
 dev.to

--- a/sources/domains/Generative AI/Dev/English.txt
+++ b/sources/domains/Generative AI/Dev/English.txt
@@ -1,2 +1,2 @@
-devsolus.com
+# Real (?) people talking about clankers
 dev.to

--- a/sources/domains/Generative AI/Teaching/Multi.txt
+++ b/sources/domains/Generative AI/Teaching/Multi.txt
@@ -1,1 +1,2 @@
+sublearn.com
 briskteaching.com

--- a/sources/domains/Generative AI/Teaching/README.md
+++ b/sources/domains/Generative AI/Teaching/README.md
@@ -1,0 +1,1 @@
+Lots of "ai powered language learning"

--- a/sources/domains/Name squatting/Brands and stores/Prizee.txt
+++ b/sources/domains/Name squatting/Brands and stores/Prizee.txt
@@ -1,0 +1,3 @@
+# https://fr.wikipedia.org/wiki/Prizee
+
+prizee.com

--- a/sources/domains/Slop/Affiliate marketing/English.txt
+++ b/sources/domains/Slop/Affiliate marketing/English.txt
@@ -1,3 +1,6 @@
+https://witchymagicks.com/
+https://bryjaimea.com/terms-of-service-1/
+https://otherworldlyoracle.com/#
 homelabaddiction.com
 selfhostpicks.com
 corelab.tech

--- a/sources/domains/Slop/Affiliate marketing/Manalink.txt
+++ b/sources/domains/Slop/Affiliate marketing/Manalink.txt
@@ -1,0 +1,7 @@
+# Manalink SAS
+# SIREN 992 055 590
+# TVA intracommunautaire : FR75 992 055 590
+
+manalnk.com
+manalinkvn.com
+worldofgeek.fr

--- a/sources/domains/Slop/Automated blogs/Bit Flip LLC.txt
+++ b/sources/domains/Slop/Automated blogs/Bit Flip LLC.txt
@@ -1,0 +1,4 @@
+# Bit Flip LLC
+# Terms of service are hosted on ghking.co
+https://ghking.co/
+https://thisvsthat.io/

--- a/sources/domains/Slop/Automated blogs/English.txt
+++ b/sources/domains/Slop/Automated blogs/English.txt
@@ -1,5 +1,6 @@
 angelicalbalance.com
 witcheslore.com
+symbolsandsynchronicity.com
 ostechnix.com
 thelinuxvault.net
 linuxlap.com

--- a/sources/domains/Slop/Automated blogs/English.txt
+++ b/sources/domains/Slop/Automated blogs/English.txt
@@ -1,3 +1,4 @@
+angelicalbalance.com
 ostechnix.com
 thelinuxvault.net
 linuxlap.com

--- a/sources/domains/Slop/Automated blogs/English.txt
+++ b/sources/domains/Slop/Automated blogs/English.txt
@@ -1,3 +1,7 @@
+https://eclecticwitchcraft.com/ # 404 festival with an AI disclosure
+devsolus.com
+spanishstep.com
+howtosayguide.com
 tux.fan
 angelicalbalance.com
 witcheslore.com

--- a/sources/domains/Slop/Automated blogs/English.txt
+++ b/sources/domains/Slop/Automated blogs/English.txt
@@ -1,3 +1,4 @@
+tux.fan
 angelicalbalance.com
 witcheslore.com
 symbolsandsynchronicity.com

--- a/sources/domains/Slop/Automated blogs/English.txt
+++ b/sources/domains/Slop/Automated blogs/English.txt
@@ -1,4 +1,5 @@
 angelicalbalance.com
+witcheslore.com
 ostechnix.com
 thelinuxvault.net
 linuxlap.com

--- a/sources/domains/Slop/Automated blogs/French.txt
+++ b/sources/domains/Slop/Automated blogs/French.txt
@@ -1,3 +1,4 @@
+worldofgeek.fr
 prizee.com
 leuromag.fr
 dailydigital.fr

--- a/sources/domains/Slop/Automated blogs/French.txt
+++ b/sources/domains/Slop/Automated blogs/French.txt
@@ -1,5 +1,5 @@
-worldofgeek.fr
-prizee.com
+https://www.pays-europe.com/mentions-legales.htm
+masquecheveuxmaison.com
 leuromag.fr
 dailydigital.fr
 fcacapital.fr

--- a/sources/domains/Slop/Automated blogs/French.txt
+++ b/sources/domains/Slop/Automated blogs/French.txt
@@ -1,3 +1,4 @@
+prizee.com
 leuromag.fr
 dailydigital.fr
 fcacapital.fr

--- a/sources/domains/Slop/Automated blogs/Unnamed Marocan network.txt
+++ b/sources/domains/Slop/Automated blogs/Unnamed Marocan network.txt
@@ -1,0 +1,7 @@
+# No name on the legal terms page, but there are
+
+https://www.poubelletri.com/confidentialite.html
+https://www.lecompost.com/mentions-legales.html
+https://www.machine-cafe-grain.com/contact.html
+https://www.aquaponie-maison.com/mentions-legales.html
+

--- a/sources/domains/Slop/Automated blogs/gh.txt
+++ b/sources/domains/Slop/Automated blogs/gh.txt
@@ -1,0 +1,9 @@
+# Farm with "gh" in the domains
+
+https://ghking.com/
+ghhomez.com
+ghfuck.com
+relaxgh.com
+ghpepe.com
+tipsgh.com
+ghcook.com

--- a/sources/domains/Slop/Content marketing/English.txt
+++ b/sources/domains/Slop/Content marketing/English.txt
@@ -1,3 +1,4 @@
+https://magickalspot.com/
 threatlistpro.com
 futurista.sk
 sendwebrequest.com # Not a lot of content, but it is just here to promote a half-related API-testing service. And not the best advice.

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,3 +1,4 @@
+spanishstep.com
 devops.dev
 willyschocolateexperience.com # https://www.theguardian.com/uk-news/2024/feb/27/glasgow-willy-wonka-experience-slammed-as-farce-as-tickets-refunded
 amazingalgorithms.com

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,7 +1,3 @@
-thisvsthat.io
-sublearn.com
-howtosayguide.com
-spanishstep.com
 devops.dev
 willyschocolateexperience.com # https://www.theguardian.com/uk-news/2024/feb/27/glasgow-willy-wonka-experience-slammed-as-farce-as-tickets-refunded
 amazingalgorithms.com

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,3 +1,4 @@
+sublearn.com
 howtosayguide.com
 spanishstep.com
 devops.dev

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,3 +1,4 @@
+howtosayguide.com
 spanishstep.com
 devops.dev
 willyschocolateexperience.com # https://www.theguardian.com/uk-news/2024/feb/27/glasgow-willy-wonka-experience-slammed-as-farce-as-tickets-refunded

--- a/sources/domains/Slop/English.txt
+++ b/sources/domains/Slop/English.txt
@@ -1,3 +1,4 @@
+thisvsthat.io
 sublearn.com
 howtosayguide.com
 spanishstep.com

--- a/sources/domains/Slop/French.txt
+++ b/sources/domains/Slop/French.txt
@@ -1,3 +1,4 @@
+facture-electronique-obligatoire.fr
 egs.school
 alouit-multimedia.com
 upandclear.org


### PR DESCRIPTION
Notes in commit comments

My personal favorites 
- https://howtosayguide.com/how-to-say-turn-on-the-light-in-harry-potter/
- https://thisvsthat.io/g-drive-vs-google-drive
- https://www.angelicalbalance.com/dreams/spiritual-meaning-of-playing-soccer-in-a-dream/

`thisvsthat.io` (that I just found) was also present in `Unsorted Gex domains.txt`. I removed it from Unsorted-Gex and kept mine. 